### PR TITLE
Fix timesheet route and login error messages

### DIFF
--- a/client/src/components/layout/sidebar.tsx
+++ b/client/src/components/layout/sidebar.tsx
@@ -34,7 +34,7 @@ export default function Sidebar() {
     },
     {
       name: "Timesheet Entry",
-      href: "/timesheet",
+      href: "/timesheet-entry",
       icon: <Clock className="h-5 w-5" />,
     },
     {


### PR DESCRIPTION
## Summary
- correct sidebar link to the timesheet-entry route
- surface server error messages when login fails

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*