### PR TITLE
Fix handling of null payroll hours

### DIFF
--- a/client/src/components/dashboard/recent-timesheet-entries.tsx
+++ b/client/src/components/dashboard/recent-timesheet-entries.tsx
@@ -173,10 +173,14 @@ function RecentTimesheetEntries({
                       <TableCell className="text-sm">{formatTime(entry.time_in)}</TableCell>
                       <TableCell className="text-sm">{formatTime(entry.time_out)}</TableCell>
                       <TableCell className="text-sm">
-                        {entry.payroll ? entry.payroll.reg_hours.toFixed(1) : "N/A"}
+                        {entry.payroll && entry.payroll.reg_hours != null
+                          ? entry.payroll.reg_hours.toFixed(1)
+                          : "N/A"}
                       </TableCell>
                       <TableCell className="text-sm">
-                        {entry.payroll ? entry.payroll.ot_hours.toFixed(1) : "N/A"}
+                        {entry.payroll && entry.payroll.ot_hours != null
+                          ? entry.payroll.ot_hours.toFixed(1)
+                          : "N/A"}
                       </TableCell>
                       <TableCell className="text-sm">{entry.miles}</TableCell>
                       <TableCell>{getStatusBadge(entry.status)}</TableCell>


### PR DESCRIPTION
## Summary
- handle null `reg_hours` and `ot_hours` in `recent-timesheet-entries`

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*
- `npm install` *(fails to fetch packages in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68433a9cd454832493fd83a7b7a77a18