### PR TITLE
Implement batch upsert and audit improvements

### DIFF
--- a/client/src/pages/reports.tsx
+++ b/client/src/pages/reports.tsx
@@ -68,10 +68,16 @@ type PayrollReportEntry = {
   payroll: {
     reg_hours: number;
     ot_hours: number;
+    pto_hours?: number;
+    holiday_worked_hours?: number;
+    holiday_non_worked_hours?: number;
     pay: number;
     mileage_pay: number;
+    misc_reimbursement?: number;
+    total_pay: number;
   };
   miles: number;
+  misc_reimbursement?: number;
 };
 
 export default function Reports() {
@@ -466,6 +472,10 @@ export default function Reports() {
                               <TableHead>Employee</TableHead>
                               <TableHead>Reg Hours</TableHead>
                               <TableHead>OT Hours</TableHead>
+                              <TableHead>PTO Hours</TableHead>
+                              <TableHead>Holiday Worked</TableHead>
+                              <TableHead>Holiday Non-Worked</TableHead>
+                              <TableHead>Misc Reimb</TableHead>
                               <TableHead>Reg Pay</TableHead>
                               <TableHead>OT Pay</TableHead>
                               <TableHead>Miles</TableHead>
@@ -477,7 +487,7 @@ export default function Reports() {
                             {payrollReport.map((entry) => {
                               const regPay = entry.payroll.pay - (entry.payroll.ot_hours * entry.employee.rate * 1.5);
                               const otPay = entry.payroll.ot_hours * entry.employee.rate * 1.5;
-                              const totalPay = entry.payroll.pay + entry.payroll.mileage_pay;
+                              const totalPay = entry.payroll.total_pay;
                               
                               return (
                                 <TableRow key={entry.id}>
@@ -487,6 +497,10 @@ export default function Reports() {
                                   </TableCell>
                                   <TableCell>{entry.payroll.reg_hours.toFixed(1)}</TableCell>
                                   <TableCell>{entry.payroll.ot_hours.toFixed(1)}</TableCell>
+                                  <TableCell>{(entry.payroll.pto_hours || 0).toFixed(1)}</TableCell>
+                                  <TableCell>{(entry.payroll.holiday_worked_hours || 0).toFixed(1)}</TableCell>
+                                  <TableCell>{(entry.payroll.holiday_non_worked_hours || 0).toFixed(1)}</TableCell>
+                                  <TableCell>{entry.payroll.misc_reimbursement ? formatCurrency(entry.payroll.misc_reimbursement) : "$0.00"}</TableCell>
                                   <TableCell>{formatCurrency(regPay)}</TableCell>
                                   <TableCell>{formatCurrency(otPay)}</TableCell>
                                   <TableCell>{entry.miles.toFixed(1)}</TableCell>

--- a/client/src/pages/timesheet-entry.tsx
+++ b/client/src/pages/timesheet-entry.tsx
@@ -486,8 +486,10 @@ export default function TimesheetEntry() {
                         <TableHead>Reg Hours</TableHead>
                         <TableHead>OT Hours</TableHead>
                         <TableHead>PTO</TableHead>
-                        <TableHead>Holiday</TableHead>
+                        <TableHead>Holiday Worked</TableHead>
+                        <TableHead>Holiday Non-Worked</TableHead>
                         <TableHead>Misc Hours</TableHead>
+                        <TableHead>Misc Reimb</TableHead>
                         <TableHead>Miles</TableHead>
                         <TableHead>Pay</TableHead>
                         <TableHead>Status</TableHead>
@@ -529,12 +531,16 @@ export default function TimesheetEntry() {
                               {entry.pto_hours ? entry.pto_hours.toFixed(1) : "0.0"}
                             </TableCell>
                             <TableCell className="text-sm">
-                              {(entry.holiday_worked_hours || entry.holiday_non_worked_hours) 
-                                ? ((entry.holiday_worked_hours || 0) + (entry.holiday_non_worked_hours || 0)).toFixed(1) 
-                                : "0.0"}
+                              {entry.holiday_worked_hours ? entry.holiday_worked_hours.toFixed(1) : "0.0"}
+                            </TableCell>
+                            <TableCell className="text-sm">
+                              {entry.holiday_non_worked_hours ? entry.holiday_non_worked_hours.toFixed(1) : "0.0"}
                             </TableCell>
                             <TableCell className="text-sm">
                               {entry.misc_hours ? entry.misc_hours.toFixed(1) : "0.0"}
+                            </TableCell>
+                            <TableCell className="text-sm">
+                              {entry.misc_reimbursement ? formatCurrency(entry.misc_reimbursement) : "$0.00"}
                             </TableCell>
                             <TableCell className="text-sm">{entry.miles}</TableCell>
                             <TableCell className="text-sm">

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -6,6 +6,7 @@ import { scrypt, randomBytes, timingSafeEqual } from "crypto";
 import { promisify } from "util";
 import { storage } from "./storage";
 import { User as SelectUser } from "@shared/schema";
+import { env } from "./config";
 
 declare global {
   namespace Express {
@@ -30,7 +31,7 @@ async function comparePasswords(supplied: string, stored: string) {
 
 export function setupAuth(app: Express) {
   const sessionSettings: session.SessionOptions = {
-    secret: process.env.SESSION_SECRET || 'timesheet-payroll-app-secret',
+    secret: env.SESSION_SECRET,
     resave: false,
     saveUninitialized: false,
     store: storage.sessionStore,

--- a/server/config.ts
+++ b/server/config.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+const envSchema = z.object({
+  DATABASE_URL: z.string().url(),
+  SESSION_SECRET: z.string().min(1),
+});
+
+export const env = envSchema.parse(process.env);

--- a/server/db.ts
+++ b/server/db.ts
@@ -2,14 +2,9 @@ import { Pool, neonConfig } from '@neondatabase/serverless';
 import { drizzle } from 'drizzle-orm/neon-serverless';
 import ws from "ws";
 import * as schema from "@shared/schema";
+import { env } from "./config";
 
 neonConfig.webSocketConstructor = ws;
 
-if (!process.env.DATABASE_URL) {
-  throw new Error(
-    "DATABASE_URL must be set. Did you forget to provision a database?",
-  );
-}
-
-export const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+export const pool = new Pool({ connectionString: env.DATABASE_URL });
 export const db = drizzle({ client: pool, schema });

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -37,6 +37,7 @@ export interface IDatabase {
   
   // Punch operations
   getPunch(id: number, company_id: number): Promise<Punch | undefined>;
+  getPunchByEmployeeAndDate(employee_id: number, date: string): Promise<Punch | undefined>;
   getPunches(company_id: number, filter?: {
     employee_id?: number,
     from_date?: Date,
@@ -158,6 +159,14 @@ export class Database implements IDatabase {
       .innerJoin(employees, eq(punches.employee_id, employees.id))
       .where(and(eq(punches.id, id), eq(employees.company_id, company_id)));
     return punch.punches || undefined;
+  }
+
+  async getPunchByEmployeeAndDate(employee_id: number, date: string): Promise<Punch | undefined> {
+    const [punch] = await db
+      .select()
+      .from(punches)
+      .where(and(eq(punches.employee_id, employee_id), eq(punches.date, date)));
+    return punch || undefined;
   }
 
   async getPunches(company_id: number, filter?: {


### PR DESCRIPTION
## Summary
- add env schema validation with zod
- use validated env vars in DB and auth setup
- support fetching punches by employee/date and update batch endpoint to upsert entries
- audit log settings changes
- update tables to show PTO/holiday and misc reimbursement fields
- update payroll entry page to send changes via batch API

## Testing
- `npm run check` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_6843a4db69808324927d68b863826219