### PR TITLE
Fix timesheet refresh & enhance payroll data

### DIFF
--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -25,6 +25,8 @@ import {
   Map,
   Users,
   Loader2,
+  CheckCircle,
+  Calendar,
 } from "lucide-react";
 
 type Employee = {
@@ -80,6 +82,14 @@ type DashboardData = {
   }>;
   overtimeLeaders: OvertimeLeader[];
   recentEntries: TimesheetEntry[];
+  lastPayroll: {
+    totalHours: number;
+    overtimeHours: number;
+    ptoHours: number;
+    totalMileage: number;
+    employeesCompleted: number;
+    totalEmployees: number;
+  };
 };
 
 export default function Dashboard() {
@@ -303,6 +313,44 @@ export default function Dashboard() {
                   icon={<Users />}
                   iconBgColor="bg-green-100"
                   iconColor="text-green-600"
+                />
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-6 mb-8">
+                <MetricCard
+                  title="Payroll Completion"
+                  value={`${dashboardData.lastPayroll.employeesCompleted}/${dashboardData.lastPayroll.totalEmployees}`}
+                  icon={<CheckCircle />}
+                  iconBgColor="bg-green-100"
+                  iconColor="text-green-600"
+                />
+                <MetricCard
+                  title="Prev Hours"
+                  value={dashboardData.lastPayroll.totalHours.toFixed(1)}
+                  icon={<Clock />}
+                  iconBgColor="bg-neutral-100"
+                  iconColor="text-neutral-600"
+                />
+                <MetricCard
+                  title="Prev OT Hours"
+                  value={dashboardData.lastPayroll.overtimeHours.toFixed(1)}
+                  icon={<Clock />}
+                  iconBgColor="bg-amber-100"
+                  iconColor="text-amber-600"
+                />
+                <MetricCard
+                  title="Prev PTO Hours"
+                  value={dashboardData.lastPayroll.ptoHours.toFixed(1)}
+                  icon={<Calendar />}
+                  iconBgColor="bg-blue-100"
+                  iconColor="text-blue-600"
+                />
+                <MetricCard
+                  title="Prev Mileage"
+                  value={dashboardData.lastPayroll.totalMileage.toFixed(1)}
+                  icon={<Map />}
+                  iconBgColor="bg-indigo-100"
+                  iconColor="text-indigo-600"
                 />
               </div>
 

--- a/client/src/pages/timesheet-entry.tsx
+++ b/client/src/pages/timesheet-entry.tsx
@@ -134,9 +134,7 @@ export default function TimesheetEntry() {
     isLoading,
     refetch,
   } = useQuery<TimesheetEntry[]>({
-    queryKey: [
-      `/api/punches?page=${page}&limit=10&searchQuery=${encodeURIComponent(searchQuery)}`,
-    ],
+    queryKey: ["/api/punches", { page, limit: 10, searchQuery }],
   });
 
   // Fetch employees for dropdown


### PR DESCRIPTION
## Summary
- refetch timesheet entries correctly by using structured query keys
- return all employees from payroll period API
- expose previous payroll metrics via dashboard endpoint
- display new payroll completion stats on the dashboard

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node' and 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6843aa31b7408324b4aeeb06800b65bf