### PR TITLE
Ensure punches belong to company

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -239,7 +239,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         created_by: req.user.id
       });
       
-      const newPunch = await storage.createPunch(validatedData);
+      const newPunch = await storage.createPunch(validatedData, req.user.company_id);
       
       // Calculate payroll
       const payroll = await storage.calculatePayroll(newPunch.id);
@@ -277,6 +277,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       const employeeId = entries[0].employee_id;
+      const validEmployee = await storage.getEmployee(employeeId, req.user.company_id);
+      if (!validEmployee) {
+        return res.status(400).json({ message: "Invalid employee" });
+      }
       const dates = entries.map(e => new Date(e.date));
       const fromDate = new Date(Math.min.apply(null, dates.map(d => d.getTime())));
       const toDate = new Date(Math.max.apply(null, dates.map(d => d.getTime())));

--- a/server/seed.ts
+++ b/server/seed.ts
@@ -1,16 +1,16 @@
 import { db } from "./db";
 import { settings } from "@shared/schema";
-import { eq } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 
 async function seedDatabase() {
   console.log("Seeding database with default settings...");
 
   // Default settings
   const defaultSettings = [
-    { key: "mileage_rate", value: "0.67" }, // Current IRS rate
-    { key: "ot_threshold", value: "8" }, // Daily overtime threshold
-    { key: "work_week_start", value: "3" }, // Wednesday = 3
-    { key: "holiday_rate_multiplier", value: "1.5" }
+    { company_id: 1, key: "mileage_rate", value: "0.67" }, // Current IRS rate
+    { company_id: 1, key: "ot_threshold", value: "8" }, // Daily overtime threshold
+    { company_id: 1, key: "work_week_start", value: "3" }, // Wednesday = 3
+    { company_id: 1, key: "holiday_rate_multiplier", value: "1.5" }
   ];
 
   for (const setting of defaultSettings) {
@@ -18,7 +18,7 @@ async function seedDatabase() {
     const [existing] = await db
       .select()
       .from(settings)
-      .where(eq(settings.key, setting.key));
+      .where(and(eq(settings.key, setting.key), eq(settings.company_id, setting.company_id)));
 
     if (!existing) {
       await db.insert(settings).values(setting);


### PR DESCRIPTION
## Summary
- validate employee belongs to company when creating or updating a punch
- handle missing punch rows safely
- pass company_id when creating punches
- check employee in batch punch route
- seed default settings with company_id

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6843b405972c83249607b59f71bf2481